### PR TITLE
Role-scope variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,33 +16,34 @@ None
 Role variables
 --------------
 ### Required variables ###
-- `api_key`: the Galaxy API key for an admin user on the target Galaxy instance
+- `galaxy_tools_api_key`: the Galaxy API key for an admin user on the target Galaxy instance
 
 ### Optional variables ###
-- `galaxy_instance_url`: (default `127.0.0.1:8080`) a URL or an IP address for
+- `galaxy_tools_instance_url`: (default `127.0.0.1:8080`) a URL or an IP address for
   the Galaxy instance where the tools are to be installed
-- `tool_list_file`: (default `files/tool_list.yaml`) the file
+- `galaxy_tools_tool_list_file`: (default `files/tool_list.yaml`) the file
   containing all the tools to be installed
-- `base_dir`: (default: `/tmp`) the system path from where this role will be run
+- `galaxy_tools_base_dir`: (default: `/tmp`) the system path from where this role will be run
 
 ### Control flow variables ###
 The following variables can be set to either `yes` or `no` to indicate if the
 given part of the role should be executed:
 
- - `galaxy_install_tools`: (default: `yes`) whether or not to run the tools installation
-    script
+ - `galaxy_tools_install_tools`: (default: `yes`) whether or not to run the
+   tools installation script
 
 Example playbook
 ----------------
 To use the role, create a playbook like the one below. Set any variables
-(remember, `api_key` is required) and save the playbook as `tools.yml`. This
-playbook assumes the role has been placed into `roles/tools` directory:
+(remember, `galaxy_tools_api_key` is required) and save the playbook as
+`tools.yml`. This playbook assumes the role has been placed into `roles/tools`
+directory:
 
     - hosts: localhost
       connection: local
       vars:
-          galaxy_instance_url: http://54.158.48.0/
-          api_key: d0ca91a20a67ec0d48612ac920ebdf59
+          galaxy_tools_instance_url: http://54.158.48.0/
+          galaxy_tools_api_key: d0ca91a20a67ec0d48612ac920ebdf59
       roles:
           - tools
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
-galaxy_install_tools: yes
+galaxy_tools_install_tools: yes
 
-galaxy_instance_url: 127.0.0.1:8080
-tool_list_file: tool_list.yaml
-base_dir: /tmp
+galaxy_tools_instance_url: 127.0.0.1:8080
+galaxy_tools_tool_list_file: tool_list.yaml
+galaxy_tools_base_dir: /tmp

--- a/tasks/tools.yml
+++ b/tasks/tools.yml
@@ -1,23 +1,23 @@
 ---
 
 - name: Create/invoke script virtualenv
-  pip: name={{ item }} virtualenv={{ base_dir }}/venv virtualenv_command="{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
+  pip: name={{ item }} virtualenv={{ galaxy_tools_base_dir }}/venv virtualenv_command="{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
   with_items:
     - pyyaml
     - bioblend
 
 - name: Place the tool management script
-  copy: src=install_tool_shed_tools.py dest={{ base_dir }}/install_tool_shed_tools.py
+  copy: src=install_tool_shed_tools.py dest={{ galaxy_tools_base_dir }}/install_tool_shed_tools.py
 
 - name: Copy tool list file
-  copy: src={{ tool_list_file }} dest={{ base_dir }}/tool_list.yaml
+  copy: src={{ galaxy_tools_tool_list_file }} dest={{ galaxy_tools_base_dir }}/tool_list.yaml
 
 - name: Install Tool Shed tools
-  command: chdir={{ base_dir }} {{ base_dir }}/venv/bin/python install_tool_shed_tools.py -t tool_list.yaml -a {{ api_key }} -g {{ galaxy_instance_url }}
+  command: chdir={{ galaxy_tools_base_dir }} {{ galaxy_tools_base_dir }}/venv/bin/python install_tool_shed_tools.py -t tool_list.yaml -a {{ galaxy_tools_api_key }} -g {{ galaxy_tools_galaxy_instance_url }}
   ignore_errors: true
 
 - name: Remove tool management scripts/file
-  file: dest={{ base_dir }}/{{ item }} state=absent
+  file: dest={{ galaxy_tools_base_dir }}/{{ item }} state=absent
   with_items:
     - install_tool_shed_tools.py
     - tool_list.yaml


### PR DESCRIPTION
Variable names for reusable roles ought to be scoped by the role name - `api_key` is very broad and might conflict with another variable in someone's playbook.

The role itself should probably be titled a bit more descriptively, like `galaxy_tools` perhaps?
