### PR TITLE
Fix conditional execution by reordering and grouping bootsrtap user c…

### DIFF
--- a/tasks/create_bootstrap_user.yml
+++ b/tasks/create_bootstrap_user.yml
@@ -8,18 +8,12 @@
   register: api_key
   when: galaxy_tools_create_bootstrap_user
 
-- set_fact: galaxy_tools_api_key="{{ api_key.stdout_lines[0] }}"  #"
-  when: galaxy_tools_create_bootstrap_user
-
 - name: Set bootstrap user as Galaxy Admin
   lineinfile: dest={{ galaxy_config_file }} state=present insertafter="app:main" regexp="admin_users =" line="admin_users = {{ galaxy_tools_admin_user }}"  #"
   when: galaxy_tools_create_bootstrap_user
 
-- name: Delete Galaxy bootstrap user
-  command: chdir={{ galaxy_server_dir }} {{ galaxy_venv_dir }}/bin/python manage_bootstrap_user.py -c {{ galaxy_config_file }} delete
-  when: galaxy_tools_delete_bootstrap_user
-
 - include: restart_galaxy.yml
 
-- name: Remove the bootstrap user management script
-  file: dest={{ galaxy_server_dir }}/manage_bootstrap_user.py state=absent
+- set_fact: galaxy_tools_api_key="{{ api_key.stdout_lines[0] }}"  #"
+  when: galaxy_tools_create_bootstrap_user
+

--- a/tasks/delete_bootstrap_user.yml
+++ b/tasks/delete_bootstrap_user.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Delete Galaxy bootstrap user
+  command: chdir={{ galaxy_server_dir }} {{ galaxy_venv_dir }}/bin/python manage_bootstrap_user.py -c {{ galaxy_config_file }} delete
+  when: galaxy_tools_delete_bootstrap_user
+
+- include: restart_galaxy.yml
+
+- name: Remove the bootstrap user management script
+  file: dest={{ galaxy_server_dir }}/manage_bootstrap_user.py state=absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 
-- include: bootstrap_user.yml
+- include: create_bootstrap_user.yml
   when: galaxy_tools_create_bootstrap_user and not galaxy_tools_api_key
 
 - include: tools.yml
   when: galaxy_tools_install_tools
 
-- include: bootstrap_user.yml
-  when: galaxy_tools_delete_bootstrap_user and not galaxy_tools_api_key
+- include: delete_bootstrap_user.yml
+  when: galaxy_tools_delete_bootstrap_user


### PR DESCRIPTION
The control flow from the tasks/mail.yml  works fine when we don't need bootstrap user for tool installation. It goes directly to tasks/main.yml->tasks/tool.yml with user supplied "galaxy_tool_api_key" and installs galaxy tools from toolshed. 

But when bootstrap user creation is required for tool installation,  The control flows from tasks/mail.yml->bootstrap_user.yml and in the middle at the set_fact: galaxy_tools_api_key="{{ api_key.stdout_lines[0] }}"  #"  step, the galaxy_tools_api_key gets a value which in turn skips the rest of the steps. Placing this step at the last fix this.

Secondly, placing the bootstrap user creation and deletion tasks into two separate files make sure that bootstrap user shouldn't be deleted before installing the tools from tasks/tool.yml. 
