### PR TITLE
Allow specifying tool_panel_section_label.

### DIFF
--- a/files/install_tool_shed_tools.py
+++ b/files/install_tool_shed_tools.py
@@ -489,6 +489,7 @@ def install_tools(options):
         tool['name'] = tool_info.get('name', None)
         tool['owner'] = tool_info.get('owner', None)
         tool['tool_panel_section_id'] = tool_info.get('tool_panel_section_id', None)
+        tool['tool_panel_section_label'] = tool_info.get('tool_panel_section_label', None)
         # Check if all required tool sections have been provided; if not, skip
         # the installation of this tool. Note that data managers are an exception
         # but they must contain string `data_manager` within the tool name.
@@ -533,7 +534,8 @@ def install_tools(options):
                     tool['tool_shed_url'], tool['name'], tool['owner'],
                     tool['revision'], tool['install_tool_dependencies'],
                     tool['install_repository_dependencies'],
-                    tool['tool_panel_section_id'])
+                    tool['tool_panel_section_id'],
+                    tool['tool_panel_section_label'])
                 tool_id = None
                 tool_status = None
                 if len(response) > 0:


### PR DESCRIPTION
... this way we can use tool_panel_section_label (instead of id) in the tool_list.yml to install tools into new galaxy instances that don't have tool panel sections yet.
