### PR TITLE
Install tools from tool_list individually

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ galaxy_tools_galaxy_instance_url: 127.0.0.1:8080
 
 # A list of files containing all the tools to be installed. See `files/tool_list.yaml.sample`
 # file for more about the format requirements of this file. The file names must be unique.
-galaxy_tools_tool_list_files: [ "tool_list.yaml" ]
+galaxy_tools_tool_list: "tool_list.yaml"
 
 # A system path from where this role will be run
 galaxy_tools_base_dir: /tmp

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,9 +8,12 @@ galaxy_tools_delete_bootstrap_user: no
 # installed
 galaxy_tools_galaxy_instance_url: 127.0.0.1:8080
 
-# A list of files containing all the tools to be installed. See `files/tool_list.yaml.sample`
+# A file containing all the tools to be installed. See `files/tool_list.yaml.sample`
 # file for more about the format requirements of this file. The file names must be unique.
 galaxy_tools_tool_list: "tool_list.yaml"
+
+# should the playbook continue when errors are found
+galaxy_tools_ignore_errors: true
 
 # A system path from where this role will be run
 galaxy_tools_base_dir: /tmp

--- a/files/install_tool_shed_tools.py
+++ b/files/install_tool_shed_tools.py
@@ -301,6 +301,9 @@ def _parse_cli_options():
     parser.add_argument("-t", "--toolsfile",
                         dest="tool_list_file",
                         help="Tools file to use (see tool_list.yaml.sample)",)
+    parser.add_argument("-y", "--yaml_tool",
+                        dest="tool_yaml",
+                        help="Install tool represented by yaml string",)
     parser.add_argument("--name",
                         help="The name of the tool to install (only applicable "
                              "if the tools file is not provided).")
@@ -458,6 +461,8 @@ def install_tools(options):
     if tool_list_file:
         tl = load_input_file(tool_list_file)  # Input file contents
         tools_info = tl['tools']  # The list of tools to install
+    elif options.tool_yaml:
+      tools_info = [yaml.load(options.tool_yaml)]
     else:
         # An individual tool was specified on the command line
         tools_info = [{"owner": options.owner,
@@ -596,7 +601,7 @@ if __name__ == "__main__":
     log = _setup_global_logger()
     options = _parse_cli_options()
     if options.tool_list_file or (options.name and options.owner and
-       options.tool_panel_section_id):
+       options.tool_panel_section_id) or (options.tool_yaml):
         install_tools(options)
     elif options.dbkeys_list_file:
         run_data_managers(options)

--- a/tasks/tools.yml
+++ b/tasks/tools.yml
@@ -14,8 +14,23 @@
 
 - name: Install Tool Shed tools
   command: chdir={{ galaxy_tools_base_dir }} {{ galaxy_tools_base_dir }}/venv/bin/python install_tool_shed_tools.py -y "{{ item | to_nice_yaml }}" -a {{ galaxy_tools_api_key }} -g {{ galaxy_tools_galaxy_instance_url }}
+  register: install_result
+  changed_when: "'installed successfully' in install_result.stderr"
+  failed_when: "'Error installing a tool' in install_result.stderr"
+  ignore_errors: yes
   with_items:
     - "{{ tools }}"
+  when: galaxy_tools_ignore_errors
+
+- name: Install Tool Shed tools
+  command: chdir={{ galaxy_tools_base_dir }} {{ galaxy_tools_base_dir }}/venv/bin/python install_tool_shed_tools.py -y "{{ item | to_nice_yaml }}" -a {{ galaxy_tools_api_key }} -g {{ galaxy_tools_galaxy_instance_url }}
+  register: install_result
+  changed_when: "'installed successfully' in install_result.stderr"
+  failed_when: "'Error installing a tool' in install_result.stderr"
+  ignore_errors: no
+  with_items:
+    - "{{ tools }}"
+  when: not galaxy_tools_ignore_errors
 
 - name: Remove tool management script
   file: dest={{ galaxy_tools_base_dir }}/install_tool_shed_tools.py state=absent

--- a/tasks/tools.yml
+++ b/tasks/tools.yml
@@ -9,17 +9,13 @@
 - name: Place the tool management script
   copy: src=install_tool_shed_tools.py dest={{ galaxy_tools_base_dir }}/install_tool_shed_tools.py
 
-- name: Copy tool list files
-  copy: src={{ item }} dest={{ galaxy_tools_base_dir }}/{{ item|basename }}
-  with_items: galaxy_tools_tool_list_files
+- name: get tool list
+  include_vars: "{{ galaxy_tools_tool_list }}"
 
 - name: Install Tool Shed tools
-  command: chdir={{ galaxy_tools_base_dir }} {{ galaxy_tools_base_dir }}/venv/bin/python install_tool_shed_tools.py -t {{ item|basename }} -a {{ galaxy_tools_api_key }} -g {{ galaxy_tools_galaxy_instance_url }}
-  with_items: galaxy_tools_tool_list_files
-
-- name: Remove tool list files
-  file: dest={{ galaxy_tools_base_dir }}/{{ item|basename }} state=absent
-  with_items: galaxy_tools_tool_list_files
+  command: chdir={{ galaxy_tools_base_dir }} {{ galaxy_tools_base_dir }}/venv/bin/python install_tool_shed_tools.py -y "{{ item | to_nice_yaml }}" -a {{ galaxy_tools_api_key }} -g {{ galaxy_tools_galaxy_instance_url }}
+  with_items:
+    - "{{ tools }}"
 
 - name: Remove tool management script
   file: dest={{ galaxy_tools_base_dir }}/install_tool_shed_tools.py state=absent


### PR DESCRIPTION
Addresses Issue #2 and https://github.com/galaxyproject/galaxy/issues/1115
This also means that downstream project need to update their use of this role.
`galaxy_tools_tool_list` replaces `galaxy_tools_tool_list_files`.
I'd say that in case multiple tool list files are needed one could run the role for each file?!
Also [this](https://docs.ansible.com/ansible/playbooks_loops.html#loops-and-includes) is coming soon ... . 
