### PR TITLE
Check if galaxy is managed by supervisor and bootstrap procedure

### DIFF
--- a/tasks/bootstrap_user.yml
+++ b/tasks/bootstrap_user.yml
@@ -8,17 +8,26 @@
   register: api_key
   when: create_user is defined and create_user
 
-- name: Set bootstrap user as Galaxy Admin
-  lineinfile: dest={{ galaxy_config_file }} state=present insertafter="app:main" regexp="admin_users =" line="admin_users = {{ galaxy_tools_admin_user }}"  #"
+- name: Set bootstrap user as Galaxy Admin if admin_users tag is already in the config file
+  replace: dest={{ galaxy_config_file }} regexp="^[ ]*admin_users[ ]*=[ ]*" replace="admin_users = {{ galaxy_tools_admin_user }},"  #"
+  register: admin_users_found
   when: create_user is defined and create_user
+
+- name: Set bootstrap user as Galaxy Admin
+  lineinfile: dest={{ galaxy_config_file }} state=present insertafter="app:main" regexp="^[ ]*admin_users[ ]*=[ ]*" line="admin_users = {{ galaxy_tools_admin_user }}"  #"
+  when: (create_user is defined) and create_user and (admin_users_found.msg is defined)
 
 - name: Delete Galaxy bootstrap user
   command: chdir={{ galaxy_server_dir }} {{ galaxy_venv_dir }}/bin/python manage_bootstrap_user.py -c {{ galaxy_config_file }} delete
   when: delete_user is defined and delete_user
 
+- name: Remove bootstrap user as Galaxy Admin if admin_users tag was already in the config file before bootstrap_user task
+  replace: dest={{ galaxy_config_file }} regexp="admin_users = {{ galaxy_tools_admin_user }}," replace="admin_users = "  #"
+  when: (delete_user is defined) and delete_user and (admin_users_found.msg is undefined)
+
 - name: Remove bootstrap user as Galaxy Admin
   lineinfile: dest={{ galaxy_config_file }} state=absent insertafter="app:main" regexp="admin_users =" line="admin_users = {{ galaxy_tools_admin_user }}"  #"
-  when: delete_user is defined and delete_user
+  when: (delete_user is defined) and delete_user and (admin_users_found.msg is defined)
 
 - include: restart_galaxy.yml
 

--- a/tasks/bootstrap_user.yml
+++ b/tasks/bootstrap_user.yml
@@ -15,7 +15,7 @@
 
 - name: Set bootstrap user as Galaxy Admin
   lineinfile: dest={{ galaxy_config_file }} state=present insertafter="app:main" regexp="^[ ]*admin_users[ ]*=[ ]*" line="admin_users = {{ galaxy_tools_admin_user }}"  #"
-  when: (create_user is defined) and create_user and (admin_users_found.msg is defined)
+  when: (create_user is defined) and create_user and (admin_users_found.msg is undefined)
 
 - name: Delete Galaxy bootstrap user
   command: chdir={{ galaxy_server_dir }} {{ galaxy_venv_dir }}/bin/python manage_bootstrap_user.py -c {{ galaxy_config_file }} delete
@@ -23,11 +23,11 @@
 
 - name: Remove bootstrap user as Galaxy Admin if admin_users tag was already in the config file before bootstrap_user task
   replace: dest={{ galaxy_config_file }} regexp="admin_users = {{ galaxy_tools_admin_user }}," replace="admin_users = "  #"
-  when: (delete_user is defined) and delete_user and (admin_users_found.msg is undefined)
+  when: (delete_user is defined) and delete_user and (admin_users_found.msg is defined)
 
 - name: Remove bootstrap user as Galaxy Admin
   lineinfile: dest={{ galaxy_config_file }} state=absent insertafter="app:main" regexp="admin_users =" line="admin_users = {{ galaxy_tools_admin_user }}"  #"
-  when: (delete_user is defined) and delete_user and (admin_users_found.msg is defined)
+  when: (delete_user is defined) and delete_user and (admin_users_found.msg is undefined)
 
 - include: restart_galaxy.yml
 

--- a/tasks/restart_galaxy.yml
+++ b/tasks/restart_galaxy.yml
@@ -1,14 +1,28 @@
 ---
 
+- name: Check if Galaxy is managed by supervisor
+  supervisorctl: name="galaxy:" state=present
+  register: supervisor_galaxy
+  ignore_errors: yes
+
+- name: Restart Galaxy
+  supervisorctl: name="galaxy:" state=restarted
+  when: supervisor_galaxy.failed is undefined
+  ignore_errors: yes
+
 - name: Stop Galaxy
   shell: "{{ galaxy_server_dir }}/run.sh --pid-file={{ galaxy_tools_pid_file_name }} --log-file={{ galaxy_tools_log_file_name }} --stop-daemon"
+  when: supervisor_galaxy.failed is defined
   ignore_errors: true
 
 - name: Wait for Galaxy to stop
   wait_for: port=8080 delay=5 state=stopped timeout=150
+  when: supervisor_galaxy.failed is defined
 
 - name: Start Galaxy
   shell: "{{ galaxy_server_dir }}/run.sh --pid-file={{ galaxy_tools_pid_file_name }} --log-file={{ galaxy_tools_log_file_name }} --daemon"
+  when: supervisor_galaxy.failed is defined
 
 - name: Wait for Galaxy to start
   wait_for: port=8080 delay=5 state=started timeout=150
+  when: supervisor_galaxy.failed is defined

--- a/tasks/restart_galaxy.yml
+++ b/tasks/restart_galaxy.yml
@@ -4,11 +4,15 @@
   supervisorctl: name="galaxy:" state=present
   register: supervisor_galaxy
   ignore_errors: yes
+  sudo: yes
+  sudo_user: root
 
 - name: Restart Galaxy
   supervisorctl: name="galaxy:" state=restarted
   when: supervisor_galaxy.failed is undefined
   ignore_errors: yes
+  sudo: yes
+  sudo_user: root
 
 - name: Stop Galaxy
   shell: "{{ galaxy_server_dir }}/run.sh --pid-file={{ galaxy_tools_pid_file_name }} --log-file={{ galaxy_tools_log_file_name }} --stop-daemon"


### PR DESCRIPTION
Changes:
   Check if galaxy is managed by supervisor, so tasks/restart_galaxy.yml will not fail to restart galaxy.
   Check if there is already a galaxy admin specified in the config file. If it is there, then only insert/remove the bootstrap user instead of replace the entire line.
