### PR TITLE
Fix "bootstrap user" and "restart galaxy" tasks

### DIFF
--- a/tasks/bootstrap_user.yml
+++ b/tasks/bootstrap_user.yml
@@ -6,12 +6,12 @@
 - name: Create Galaxy bootstrap user
   command: chdir={{ galaxy_server_dir }} {{ galaxy_venv_dir }}/bin/python manage_bootstrap_user.py -c {{ galaxy_config_file }} create -e {{ galaxy_tools_admin_user }} -p {{ galaxy_tools_admin_user_password }}
   register: api_key
-  when: create_user is defined and create_user
+  when: (create_user is defined) and create_user
 
 - name: Check/Set bootstrap user as Galaxy Admin if admin_users tag is already in the config file
   replace: dest={{ galaxy_config_file }} regexp="^[ ]*admin_users[ ]*=[ ]*" replace="admin_users = {{ galaxy_tools_admin_user }},"  #"
   register: admin_users_found
-  when: create_user is defined and create_user
+  when: (create_user is defined) and create_user
 
 - name: Set bootstrap user as Galaxy Admin
   lineinfile: dest={{ galaxy_config_file }} state=present insertafter="app:main" regexp="^[ ]*admin_users[ ]*=[ ]*" line="admin_users = {{ galaxy_tools_admin_user }}"  #"
@@ -19,11 +19,12 @@
 
 - name: Delete Galaxy bootstrap user
   command: chdir={{ galaxy_server_dir }} {{ galaxy_venv_dir }}/bin/python manage_bootstrap_user.py -c {{ galaxy_config_file }} delete
-  when: delete_user is defined and delete_user
+  when: (delete_user is defined) and delete_user
 
 - name: Remove bootstrap user as Galaxy Admin if admin_users tag was already in the config file before bootstrap_user task
   replace: dest={{ galaxy_config_file }} regexp="admin_users = {{ galaxy_tools_admin_user }}," replace="admin_users = "  #"
-  when: (delete_user is defined) and delete_user and (admin_users_found.msg != "")
+  register: admin_users_found
+  when: (delete_user is defined) and delete_user
 
 - name: Remove bootstrap user as Galaxy Admin
   lineinfile: dest={{ galaxy_config_file }} state=absent insertafter="app:main" regexp="admin_users =" line="admin_users = {{ galaxy_tools_admin_user }}"  #"

--- a/tasks/bootstrap_user.yml
+++ b/tasks/bootstrap_user.yml
@@ -8,14 +8,14 @@
   register: api_key
   when: create_user is defined and create_user
 
-- name: Set bootstrap user as Galaxy Admin if admin_users tag is already in the config file
+- name: Check/Set bootstrap user as Galaxy Admin if admin_users tag is already in the config file
   replace: dest={{ galaxy_config_file }} regexp="^[ ]*admin_users[ ]*=[ ]*" replace="admin_users = {{ galaxy_tools_admin_user }},"  #"
   register: admin_users_found
   when: create_user is defined and create_user
 
 - name: Set bootstrap user as Galaxy Admin
   lineinfile: dest={{ galaxy_config_file }} state=present insertafter="app:main" regexp="^[ ]*admin_users[ ]*=[ ]*" line="admin_users = {{ galaxy_tools_admin_user }}"  #"
-  when: (create_user is defined) and create_user and (admin_users_found.msg is undefined)
+  when: (create_user is defined) and create_user and (admin_users_found.msg == "")
 
 - name: Delete Galaxy bootstrap user
   command: chdir={{ galaxy_server_dir }} {{ galaxy_venv_dir }}/bin/python manage_bootstrap_user.py -c {{ galaxy_config_file }} delete
@@ -23,11 +23,11 @@
 
 - name: Remove bootstrap user as Galaxy Admin if admin_users tag was already in the config file before bootstrap_user task
   replace: dest={{ galaxy_config_file }} regexp="admin_users = {{ galaxy_tools_admin_user }}," replace="admin_users = "  #"
-  when: (delete_user is defined) and delete_user and (admin_users_found.msg is defined)
+  when: (delete_user is defined) and delete_user and (admin_users_found.msg != "")
 
 - name: Remove bootstrap user as Galaxy Admin
   lineinfile: dest={{ galaxy_config_file }} state=absent insertafter="app:main" regexp="admin_users =" line="admin_users = {{ galaxy_tools_admin_user }}"  #"
-  when: (delete_user is defined) and delete_user and (admin_users_found.msg is undefined)
+  when: (delete_user is defined) and delete_user and (admin_users_found.msg == "")
 
 - include: restart_galaxy.yml
 

--- a/tasks/bootstrap_user.yml
+++ b/tasks/bootstrap_user.yml
@@ -8,17 +8,26 @@
   register: api_key
   when: create_user is defined and create_user
 
-- name: Set bootstrap user as Galaxy Admin
-  lineinfile: dest={{ galaxy_config_file }} state=present insertafter="app:main" regexp="admin_users =" line="admin_users = {{ galaxy_tools_admin_user }}"  #"
+- name: Set bootstrap user as Galaxy Admin if admin_users tag is already in the config file
+  replace: dest={{ galaxy_config_file }} regexp="^[ ]*admin_users[ ]*=[ ]*" replace="admin_users = {{ galaxy_tools_admin_user }},"  #"
+  register: admin_users_found
   when: create_user is defined and create_user
+
+- name: Set bootstrap user as Galaxy Admin
+  lineinfile: dest={{ galaxy_config_file }} state=present insertafter="app:main" regexp="^[ ]*admin_users[ ]*=[ ]*" line="admin_users = {{ galaxy_tools_admin_user }}"  #"
+  when: (create_user is defined) and create_user and (admin_users_found.msg is defined)
 
 - name: Delete Galaxy bootstrap user
   command: chdir={{ galaxy_server_dir }} {{ galaxy_venv_dir }}/bin/python manage_bootstrap_user.py -c {{ galaxy_config_file }} delete
   when: delete_user is defined and delete_user
 
+- name: Remove bootstrap user as Galaxy Admin if admin_users tag was already in the config file before bootstrap_user task
+  replace: dest={{ galaxy_config_file }} regexp="admin_users = {{ galaxy_tools_admin_user }}," replace="admin_users = "  #"
+  when: (delete_user is defined) and delete_user and (admin_users_found.msg is undefined)
+
 - name: Remove bootstrap user as Galaxy Admin
   lineinfile: dest={{ galaxy_config_file }} state=absent insertafter="app:main" regexp="admin_users =" line="admin_users = {{ galaxy_tools_admin_user }}"  #"
-  when: delete_user is defined and delete_user
+  when: (delete_user is defined) and delete_user and (admin_users_found.msg is defined)
 
 - include: restart_galaxy.yml
 

--- a/tasks/bootstrap_user.yml
+++ b/tasks/bootstrap_user.yml
@@ -15,7 +15,7 @@
 
 - name: Set bootstrap user as Galaxy Admin
   lineinfile: dest={{ galaxy_config_file }} state=present insertafter="app:main" regexp="^[ ]*admin_users[ ]*=[ ]*" line="admin_users = {{ galaxy_tools_admin_user }}"  #"
-  when: (create_user is defined) and create_user and (admin_users_found.msg is defined)
+  when: (create_user is defined) and create_user and (admin_users_found.msg is undefined)
 
 - name: Delete Galaxy bootstrap user
   command: chdir={{ galaxy_server_dir }} {{ galaxy_venv_dir }}/bin/python manage_bootstrap_user.py -c {{ galaxy_config_file }} delete
@@ -23,11 +23,11 @@
 
 - name: Remove bootstrap user as Galaxy Admin if admin_users tag was already in the config file before bootstrap_user task
   replace: dest={{ galaxy_config_file }} regexp="admin_users = {{ galaxy_tools_admin_user }}," replace="admin_users = "  #"
-  when: (delete_user is defined) and delete_user and (admin_users_found.msg is undefined)
+  when: (delete_user is defined) and delete_user and (admin_users_found.msg is defined)
 
 - name: Remove bootstrap user as Galaxy Admin
   lineinfile: dest={{ galaxy_config_file }} state=absent insertafter="app:main" regexp="admin_users =" line="admin_users = {{ galaxy_tools_admin_user }}"  #"
-  when: (delete_user is defined) and delete_user and (admin_users_found.msg is defined)
+  when: (delete_user is defined) and delete_user and (admin_users_found.msg is undefined)
 
 - include: restart_galaxy.yml
 

--- a/tasks/restart_galaxy.yml
+++ b/tasks/restart_galaxy.yml
@@ -1,14 +1,28 @@
 ---
 
+- name: Check if Galaxy is managed by supervisor
+  supervisorctl: name="galaxy:" state=present
+  register: supervisor_galaxy
+  ignore_errors: yes
+
+- name: Restart Galaxy
+  supervisorctl: name="galaxy:" state=restarted
+  when: supervisor_galaxy.failed is undefined
+  ignore_errors: yes
+
 - name: Stop Galaxy
   shell: "{{ galaxy_server_dir }}/run.sh --pid-file={{ galaxy_tools_pid_file_name }} --log-file={{ galaxy_tools_log_file_name }} --stop-daemon"
+  when: supervisor_galaxy.failed is defined
   ignore_errors: true
 
 - name: Wait for Galaxy to stop
   wait_for: port=8080 delay=5 state=stopped timeout=150
+  when: supervisor_galaxy.failed is defined
 
 - name: Start Galaxy
   shell: "{{ galaxy_server_dir }}/run.sh --pid-file={{ galaxy_tools_pid_file_name }} --log-file={{ galaxy_tools_log_file_name }} --daemon"
+  when: supervisor_galaxy.failed is defined
 
 - name: Wait for Galaxy to start
   wait_for: port=8080 delay=5 state=started timeout=150
+  when: supervisor_galaxy.failed is defined

--- a/tasks/restart_galaxy.yml
+++ b/tasks/restart_galaxy.yml
@@ -4,11 +4,15 @@
   supervisorctl: name="galaxy:" state=present
   register: supervisor_galaxy
   ignore_errors: yes
+  sudo: yes
+  sudo_user: root
 
 - name: Restart Galaxy
   supervisorctl: name="galaxy:" state=restarted
   when: supervisor_galaxy.failed is undefined
   ignore_errors: yes
+  sudo: yes
+  sudo_user: root
 
 - name: Stop Galaxy
   shell: "{{ galaxy_server_dir }}/run.sh --pid-file={{ galaxy_tools_pid_file_name }} --log-file={{ galaxy_tools_log_file_name }} --stop-daemon"


### PR DESCRIPTION
Changes:
   When galaxy is managed by supervisor, tasks/restart_galaxy.yml restarts galaxy properly.
   When there is a galaxy admin specified in galaxy.ini, tasks/bootstrap_user.yml do not remove it.
