### PR TITLE
Added the -u switch to the delete bootstrap user commandline so manag…

### DIFF
--- a/tasks/bootstrap_user.yml
+++ b/tasks/bootstrap_user.yml
@@ -18,7 +18,7 @@
   when: (create_user is defined) and create_user and (admin_users_found.msg == "")
 
 - name: Delete Galaxy bootstrap user
-  command: chdir={{ galaxy_server_dir }} {{ galaxy_venv_dir }}/bin/python manage_bootstrap_user.py -c {{ galaxy_config_file }} delete
+  command: chdir={{ galaxy_server_dir }} {{ galaxy_venv_dir }}/bin/python manage_bootstrap_user.py -c {{ galaxy_config_file }} delete -u {{ galaxy_tools_admin_username }}
   when: (delete_user is defined) and delete_user
 
 - name: Remove bootstrap user as Galaxy Admin if admin_users tag was already in the config file before bootstrap_user task


### PR DESCRIPTION
…e_bootstrap_user.py knows which user to delete.

galaxy_tools_admin_user was not being deleted out of the database. Adding the -u switch to the manage_bootstrap_user.py's delete command fixed it for me.
