### PR TITLE
Workaround missing logging functionality in python2.6

### DIFF
--- a/files/install_tool_shed_tools.py
+++ b/files/install_tool_shed_tools.py
@@ -46,7 +46,10 @@ from bioblend.galaxy.client import ConnectionError
 # Omit (most of the) logging by external libraries
 logging.getLogger('bioblend').setLevel(logging.ERROR)
 logging.getLogger('requests').setLevel(logging.ERROR)
-logging.captureWarnings(True)  # Capture HTTPS warngings from urllib3
+try:
+    logging.captureWarnings(True)  # Capture HTTPS warngings from urllib3
+except AttributeError:
+    pass
 
 MTS = 'https://toolshed.g2.bx.psu.edu/'  # Main Tool Shed
 


### PR DESCRIPTION
logging doesn't have captureWarnings on python <2.7, so that was one of the problems mentioned [here](http://dev.list.galaxyproject.org/ERROR-PIP-is-not-a-legl-parament-of-an-Ansible-Play-td4669045.html)

Ping @afgane 
