### PR TITLE
add possibility for predefined api key

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,9 @@ galaxy_tools_ignore_errors: true
 # A system path from where this role will be run
 galaxy_tools_base_dir: /tmp
 
+# Set this to yes and change galaxy_tools_api_key to a string to create a predefined api key for the bootstrap user.
+galaxy_tools_admin_user_preset_api_key: no
+
 # Blank variable to make sure it's defined
 galaxy_tools_api_key: ''
 

--- a/files/manage_bootstrap_user.py
+++ b/files/manage_bootstrap_user.py
@@ -95,7 +95,7 @@ def _setup_global_logger():
     return logger
 
 
-def create_api_key(app, user, preset_api_key):
+def create_api_key(app, user, preset_api_key=False):
     """
     Creates a random new api key if preset_api_key is False,
     otherwise sets the API key to preset_api_key.
@@ -112,7 +112,7 @@ def create_api_key(app, user, preset_api_key):
     return api_key
 
 
-def get_or_create_api_key(app, user, preset_api_key):
+def get_or_create_api_key(app, user, preset_api_key=False):
     if user.api_keys:
         key = user.api_keys[0].key
     else:
@@ -203,7 +203,7 @@ def get_bootstrap_app(ini_file):
     return app
 
 
-def create_bootstrap_user(ini_file, username, user_email, password, preset_api_key):
+def create_bootstrap_user(ini_file, username, user_email, password, preset_api_key=False):
     app = get_bootstrap_app(ini_file)
     user = get_or_create_user(app, user_email, password, username)
     if user is not None:

--- a/files/manage_bootstrap_user.py
+++ b/files/manage_bootstrap_user.py
@@ -176,8 +176,8 @@ def validate_email(email):
 
 
 def validate_password(password):
-    if len(password) < 6:
-        return "Use a password of at least 6 characters"
+    if len(password) < 5:
+        return "Use a password of at least 5 characters"
     return ''
 
 

--- a/tasks/bootstrap_user.yml
+++ b/tasks/bootstrap_user.yml
@@ -4,7 +4,15 @@
   copy: src=manage_bootstrap_user.py dest={{ galaxy_server_dir }}/manage_bootstrap_user.py owner={{ galaxy_user_name }}
 
 - name: Create Galaxy bootstrap user
-  command: chdir={{ galaxy_server_dir }} {{ galaxy_venv_dir }}/bin/python manage_bootstrap_user.py -c {{ galaxy_config_file }} create -e {{ galaxy_tools_admin_user }} -u {{ galaxy_tools_admin_username }} -p {{ galaxy_tools_admin_user_password }}
+  command: >
+    chdir={{ galaxy_server_dir }} {{ galaxy_venv_dir }}/bin/python manage_bootstrap_user.py
+    -c {{ galaxy_config_file }} create
+    -e {{ galaxy_tools_admin_user }}
+    -u {{ galaxy_tools_admin_username }}
+    -p {{ galaxy_tools_admin_user_password }}
+    {% if galaxy_tools_admin_user_preset_api_key|bool %}
+    -a {{ galaxy_tools_api_key }}
+    {% endif %}
   register: api_key
   when: (create_user is defined) and create_user
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - include: bootstrap_user.yml create_user={{ galaxy_tools_create_bootstrap_user }}
-  when: galaxy_tools_create_bootstrap_user and not galaxy_tools_api_key
+  when: galaxy_tools_create_bootstrap_user and (not galaxy_tools_api_key or galaxy_tools_admin_user_preset_api_key)
 
 - include: tools.yml
   when: galaxy_tools_install_tools


### PR DESCRIPTION
This should eliminate the necessity to have another script in https://github.com/galaxyproject/ansible-galaxy-extras/blob/master/templates/create_galaxy_user.py.j2 that does almost the same thing.
I reduced the minimum password length to 5, since @bgruening and me are using admin as our preset password.
