### PR TITLE
add pip pacakges pyyaml, bioblend

### DIFF
--- a/tasks/tools.yml
+++ b/tasks/tools.yml
@@ -4,6 +4,8 @@
   pip: name={{ item }} virtualenv={{ galaxy_tools_base_dir }}/venv virtualenv_command="{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
   with_items:
     - ephemeris==0.4.0  # Pinned version should make sure ephemeris version matches what the role has been tested with
+    - pyyaml
+    - bioblend
 
 - include: install_tool_list.yml
   with_items: '{{ galaxy_tools_tool_list_files }}'


### PR DESCRIPTION
The ephemeris scripts require pyyaml and bioblend dependencies. These were not available by default in the virtualenv. 