### PR TITLE
Partially addresses: https://github.com/galaxyproject/ansible-galaxy-tools/issues/48

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,11 @@ install:
   # Use the Galaxy Docker image to test the role
   - docker run --name galaxy -d -p 8080:80 quay.io/bgruening/galaxy
 
+  # Wait for web server port to come up
+  - ansible localhost -c local -m wait_for -a "port=8080 delay=5 state=started timeout=150"
+
+  # Wait for Galaxy to respond
+  - ansible localhost -c local -m uri -a "url=http://localhost:8080/ register=result until='result.status[0] in [\"2\", \"3\"]' retries=50 delay=3 ignore_error=True"
 script:
   # Check the role works in the test playbook.
   - ansible-playbook -i "localhost," -c local -e galaxy_tools_galaxy_instance_url=http://127.0.0.1:8080 -e galaxy_runs_in_docker=yes -e galaxy_tools_api_key=admin test_playbook.yml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/galaxyproject/ansible-galaxy-tools.svg?branch=master)](https://travis-ci.org/galaxyproject/ansible-galaxy-tools)
+
 This Ansible role is for automated installation of tools from a Tool Shed into
 Galaxy.
 

--- a/tests/test_playbook.yml
+++ b/tests/test_playbook.yml
@@ -2,7 +2,7 @@
   gather_facts: False
   connection: local
   vars:
+      galaxy_tools_ignore_errors: False
       galaxy_tools_tool_list_files: [ "files/tool_list.yaml.sample" ]
   roles:
       - ansible-galaxy-tools
-


### PR DESCRIPTION
Added travis build badge
Fail tests if tools fail to install
Wait for galaxy to be ready before running tests