### PR TITLE
Implement run-data-managers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 
 galaxy_tools_install_tools: yes
+galaxy_tools_install_data_managers: yes 
 galaxy_tools_install_workflows: no
 galaxy_tools_create_bootstrap_user: no
 galaxy_tools_delete_bootstrap_user: no
@@ -11,11 +12,15 @@ galaxy_restart_handler_enabled: no
 
 # A URL or an IP address for the Galaxy instance where the tools are to be
 # installed
-galaxy_tools_galaxy_instance_url: 127.0.0.1:8080
+galaxy_tools_galaxy_instance_url: http://127.0.0.1:8080
 
 # A list of yml files that list the tools to be installed. See `files/tool_list.yaml.sample`
 # file for more about the format requirements of this file. The file names must be unique.
 galaxy_tools_tool_list_files: [ "tool_list.yaml" ]
+
+# A yml file that lists the data-managers and genomes to be installed
+# see `files/tool_list.yaml.sample`
+galaxy_tools_data_managers_list: "run_data_managers.yaml"
 
 # should the playbook continue when errors are found
 galaxy_tools_ignore_errors: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 galaxy_tools_install_tools: yes
-galaxy_tools_install_data_managers: yes 
+galaxy_tools_install_data_managers: no 
 galaxy_tools_install_workflows: no
 galaxy_tools_create_bootstrap_user: no
 galaxy_tools_delete_bootstrap_user: no

--- a/files/run_data_managers.yaml
+++ b/files/run_data_managers.yaml
@@ -1,0 +1,37 @@
+# configuration for fetch and index genomes
+
+data_managers:
+    # Data manager ID
+    - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_dbkeys_all_fasta/data_manager_fetch_genome_all_fasta_dbkey/0.0.2
+      # tool parameters, nested parameters should be specified using a pipe (|)
+      params:
+        - 'dbkey_source|dbkey': '{{ item }}'
+        - 'reference_source|reference_source_selector': 'ucsc'
+        - 'reference_source|requested_dbkey': '{{ item }}'
+      # Items refere to a list of variables you want to run this data manager. You can use them inside the param field with {{ item }}
+      # In case of genome for example you can run this DM with multiple genomes, or you could give multiple URLs.
+      items:
+        - ce6
+        #- dm3
+        #- mm9
+      # Name of the data-tables you want to reload after your DM are finished. This can be important for subsequent data managers
+      data_table_reload:
+        - all_fasta
+        - __dbkeys__
+
+#    - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_bowtie2_index_builder/bowtie2_index_builder_data_manager/2.2.6
+#      params:
+#        - 'all_fasta_source': '{{ item.id }}'
+#        - 'sequence_name': '{{ item.name }}'
+#        - 'sequence_id': '{{ item.id }}'
+#      items:
+#        - id: ce8
+#          name: C. elegans (ce8)
+#        - id: dm3
+#          name: D. melanogaster Apr. 2006 (BDGP r5/dm3)
+#        - id: mm9
+#          name: M. musculus July 2007 (NCBI37/mm9)
+#      data_table_reload:
+#        # Bowtie creates indices for Bowtie and TopHat
+#        - bowtie2_indexes
+#        - tophat2_indexes

--- a/files/tool_list.yaml.sample
+++ b/files/tool_list.yaml.sample
@@ -54,3 +54,8 @@ tools:
   tool_panel_section_label: 'BED tools'
   revisions:
   - 2cd7e321d259
+- name: data_manager_fetch_genome_dbkeys_all_fasta
+  owner: devteam
+  tool_shed_url: https://toolshed.g2.bx.psu.edu
+  revisions:
+  - b1bc53e9bbc5

--- a/tasks/data_managers.yml
+++ b/tasks/data_managers.yml
@@ -1,0 +1,26 @@
+---
+
+- name: Create/invoke script virtualenv
+  pip: name={{ item }} virtualenv={{ galaxy_tools_base_dir }}/venv virtualenv_command="{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
+  with_items:
+    - ephemeris==0.8.0  # Pinned version should make sure ephemeris version matches what the role has been tested with
+    - bioblend==0.10.0
+
+- name: Copy galaxy_tools_data_managers_list in venv
+  copy: src="{{ galaxy_tools_data_managers_list }}" dest="{{ galaxy_tools_base_dir }}/venv/bin/data_managers_list.yaml"
+
+- name: Install Data-managers and Genomes
+  command: '{{ galaxy_tools_base_dir }}/venv/bin/run-data-managers -a "{{ galaxy_tools_api_key }}" -g "{{ galaxy_tools_galaxy_instance_url }}" --config "{{ galaxy_tools_base_dir }}/venv/bin/data_managers_list.yaml" '
+  register: install_result
+  changed_when: "install_result.stderr.find('Failed jobs: 0') != -1"
+  failed_when: "(install_result.stderr.find('Tool not found or not accessible') != -1) or not(install_result.stderr.find('Failed jobs: 0') != -1) or (install_result.rc != 0)"
+  ignore_errors: "{{ galaxy_tools_ignore_errors }}"
+  notify:
+    - ansible-galaxy-tools restart galaxy
+    
+- name: Display data_managers results
+  debug:
+    msg:
+      - "{{ install_result.stderr }}"
+      - "{{ install_result.stdout }}"
+      

--- a/tasks/install_tool_list.yml
+++ b/tasks/install_tool_list.yml
@@ -3,7 +3,7 @@
   include_vars: "{{ tool_list_file }}"
 
 - name: Install Tool Shed tools
-  command: '{{ galaxy_tools_base_dir }}/venv/bin/shed-install -y "{{ item | to_nice_yaml }}" -a "{{ galaxy_tools_api_key }}" -g "{{ galaxy_tools_galaxy_instance_url }}"'
+  command: '{{ galaxy_tools_base_dir }}/venv/bin/shed-tools install -y "{{ item | to_nice_yaml }}" -a "{{ galaxy_tools_api_key }}" -g "{{ galaxy_tools_galaxy_instance_url }}"'
   register: install_result
   changed_when: "'installed successfully' in install_result.stderr"
   failed_when: ('Error installing' in install_result.stderr) or ('Missing required' in install_result.stderr) or (install_result.rc != 0)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,9 @@
 - include: tools.yml
   when: galaxy_tools_install_tools
 
+- include: data_managers.yml
+  when: galaxy_tools_install_data_managers
+
 - include: workflows.yml
   when: galaxy_tools_install_workflows
 

--- a/tasks/tools.yml
+++ b/tasks/tools.yml
@@ -3,7 +3,8 @@
 - name: Create/invoke script virtualenv
   pip: name={{ item }} virtualenv={{ galaxy_tools_base_dir }}/venv virtualenv_command="{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
   with_items:
-    - ephemeris==0.4.0  # Pinned version should make sure ephemeris version matches what the role has been tested with
+    - ephemeris==0.8.0  # Pinned version should make sure ephemeris version matches what the role has been tested with
+    - bioblend==0.10.0
 
 - include: install_tool_list.yml
   with_items: '{{ galaxy_tools_tool_list_files }}'

--- a/tests/test_playbook.yml
+++ b/tests/test_playbook.yml
@@ -4,6 +4,9 @@
   vars:
       galaxy_tools_ignore_errors: False
       galaxy_tools_tool_list_files: [ "files/tool_list.yaml.sample" ]
+      galaxy_tools_data_managers_list: files/run_data_managers.yaml
+      galaxy_tools_galaxy_instance_url: http://localhost:8080/
+      galaxy_tools_install_data_managers: yes
   pre_tasks:
     - name: Make sure Galaxy is ready before running tests
       uri: url="http://localhost:8080/" state=present


### PR DESCRIPTION
- switch to ephemeris 0.8.0 (and bioblend 0.10.0) and implement the new `shed-tool install` and `run-data-managers` in ansible-galaxy-tools role.
- minor changes in `test_playbook.yml` to test the data_managers.yml task
- input a real url in the variable `galaxy_tools_galaxy_instance_url`