### PR TITLE
removed deprecated ansible syntax

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 - name: ansible-galaxy-tools restart galaxy
-  include: restart_galaxy.yml
+  include_tasks: restart_galaxy.yml
   when: galaxy_restart_handler_enabled|bool

--- a/handlers/restart_galaxy.yml
+++ b/handlers/restart_galaxy.yml
@@ -10,13 +10,13 @@
 # All of the following includes are in the tasks folder
 
 - name: Restart Galaxy (in docker container)
-  include: restart_galaxy_docker.yml
+  include_tasks: restart_galaxy_docker.yml
   when: galaxy_runs_in_docker|bool
 
 - name: Restart Galaxy (run.sh method)
-  include: restart_galaxy_run_sh.yml
+  include_tasks: restart_galaxy_run_sh.yml
   when: (supervisor_galaxy.failed is defined) and not (galaxy_runs_in_docker|bool)
 
 - name: Restart Galaxy (supervisor method)
-  include: restart_galaxy_supervisor.yml
+  include_tasks: restart_galaxy_supervisor.yml
   when: (supervisor_galaxy.failed is undefined) and not (galaxy_runs_in_docker|bool)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,18 @@
 ---
 - fail: msg="Installed ansible version {{ ansible_version.full }}, but ansible version > 2.1.1.1 required"
-  when: "{{ ansible_version.full | version_compare('2.1.1.1', '<') }}"
+  when: ansible_version.full | version_compare('2.1.1.1', '<')
 
-- include: bootstrap_user.yml create_user={{ galaxy_tools_create_bootstrap_user }}
+- include_tasks: bootstrap_user.yml create_user={{ galaxy_tools_create_bootstrap_user }}
   when: galaxy_tools_create_bootstrap_user and (not galaxy_tools_api_key or galaxy_tools_admin_user_preset_api_key)
 
-- include: tools.yml
+- include_tasks: tools.yml
   when: galaxy_tools_install_tools
 
-- include: data_managers.yml
+- include_tasks: data_managers.yml
   when: galaxy_tools_install_data_managers
 
-- include: workflows.yml
+- include_tasks: workflows.yml
   when: galaxy_tools_install_workflows
 
-- include: bootstrap_user.yml delete_user={{ galaxy_tools_delete_bootstrap_user }}
+- include_tasks: bootstrap_user.yml delete_user={{ galaxy_tools_delete_bootstrap_user }}
   when: galaxy_tools_delete_bootstrap_user

--- a/tasks/tools.yml
+++ b/tasks/tools.yml
@@ -6,7 +6,7 @@
     - ephemeris==0.8.0  # Pinned version should make sure ephemeris version matches what the role has been tested with
     - bioblend==0.10.0
 
-- include: install_tool_list.yml
+- include_tasks: install_tool_list.yml
   with_items: '{{ galaxy_tools_tool_list_files }}'
   loop_control:
     loop_var: tool_list_file


### PR DESCRIPTION
 jinja2 templating delimiters in when statements and `include` have been deprecated.