### PR TITLE
Fix ansible syntax and pin ansible to 2.7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - docker info
 
 install:
-  - pip install ansible==2.4
+  - pip install ansible==2.7.4
 
   # Add ansible.cfg to pick up roles path.
   - printf '[defaults]\nroles_path = ../' > ansible.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - docker info
 
 install:
-  - pip install ansible
+  - pip install ansible==2.4
 
   # Add ansible.cfg to pick up roles path.
   - printf '[defaults]\nroles_path = ../' > ansible.cfg

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,9 @@
 - fail: msg="Installed ansible version {{ ansible_version.full }}, but ansible version > 2.1.1.1 required"
   when: ansible_version.full | version_compare('2.1.1.1', '<')
 
-- include_tasks: bootstrap_user.yml create_user={{ galaxy_tools_create_bootstrap_user }}
+- include_tasks: "bootstrap_user.yml"
+  vars:
+    create_user: "{{ galaxy_tools_create_bootstrap_user }}"
   when: galaxy_tools_create_bootstrap_user and (not galaxy_tools_api_key or galaxy_tools_admin_user_preset_api_key)
 
 - include_tasks: tools.yml
@@ -14,5 +16,7 @@
 - include_tasks: workflows.yml
   when: galaxy_tools_install_workflows
 
-- include_tasks: bootstrap_user.yml delete_user={{ galaxy_tools_delete_bootstrap_user }}
+- include_tasks: "bootstrap_user.yml"
+  vars:
+    delete_user: "{{ galaxy_tools_delete_bootstrap_user }}"
   when: galaxy_tools_delete_bootstrap_user


### PR DESCRIPTION
My two cents for the ansible code synthax. In addition, I propose to pin ansible to 2.7.4, because this is also the version installed when using apt in trusty, which should insure more interoperability with docker image build on ubunty:14.04 and loaded with ansible using apt.

I suggest that this is done with all ansible repos of the galaxyproject, to make life easier. But I am of course aware that migration of code for compatibility with ansible 2.7.4 may take some efforts.

I'll next work on ansible-galaxy-os because it is in some case the first layer of docker images. Thus I really think that pining ansible version deserve effort