### PR TITLE
adapt manage_bootstrap_user.py to change in lib/galaxy/web/security introduced in Galaxy release_19.05

### DIFF
--- a/files/manage_bootstrap_user.py
+++ b/files/manage_bootstrap_user.py
@@ -18,7 +18,11 @@ eggs.require("SQLAlchemy >= 0.4")
 eggs.require("mercurial")
 
 import galaxy.config
-from galaxy.web import security
+
+try:
+    from galaxy.web.security import SecurityHelper as Security
+except ImportError:
+    from galaxy.security.idencoding import IdEncodingHelper as Security
 from galaxy.model import mapping
 
 logging.captureWarnings(True)
@@ -43,7 +47,7 @@ class BootstrapGalaxyApplication(object):
                                   self.config.database_connection,
                                   engine_options={},
                                   create_tables=False)
-        self.security = security.SecurityHelper(id_secret=self.config.id_secret)
+        self.security = Security(id_secret=self.config.id_secret)
 
     @property
     def sa_session(self):

--- a/files/manage_bootstrap_user.py
+++ b/files/manage_bootstrap_user.py
@@ -16,6 +16,8 @@ import yaml
 try:
     from galaxy.security.idencoding import IdEncodingHelper as Security
 except ImportError:
+    # maintains backwards compatibility with galaxy versions < 19.05
+    # see https://github.com/galaxyproject/galaxy/pull/7560
     from galaxy.web.security import SecurityHelper as Security
 
 eggs.require("SQLAlchemy >= 0.4")

--- a/files/manage_bootstrap_user.py
+++ b/files/manage_bootstrap_user.py
@@ -214,7 +214,10 @@ def get_bootstrap_app(ini_file):
     return app
 
 
-def create_bootstrap_user(ini_file, username, user_email, password,
+def create_bootstrap_user(ini_file,
+                          username,
+                          user_email,
+                          password,
                           preset_api_key=None):
     app = get_bootstrap_app(ini_file)
     user = get_or_create_user(app, user_email, password, username)
@@ -277,7 +280,10 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.action == "create":
-        create_bootstrap_user(args.config, args.username, args.email,
-                              args.password, args.preset_api_key)
+        create_bootstrap_user(args.config,
+                              args.username,
+                              args.email,
+                              args.password,
+                              args.preset_api_key)
     elif args.action == "delete":
         delete_bootstrap_user(args.config, args.username)


### PR DESCRIPTION
see changes here https://github.com/galaxyproject/galaxy/commit/528497f7c42f81d4114eeccc559ad16366c423dd

The fix allows successfully bootstrapping a user in release_19.05 and preserves backward compatibility with < release_19.05