### PR TITLE
Syntax update to fix ansible deprecation warnings.

### DIFF
--- a/tasks/data_managers.yml
+++ b/tasks/data_managers.yml
@@ -1,10 +1,13 @@
 ---
 
-- name: Create/invoke script virtualenv
-  pip: name={{ item }} virtualenv={{ galaxy_tools_base_dir }}/venv virtualenv_command="{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
-  with_items:
-    - ephemeris==0.8.0  # Pinned version should make sure ephemeris version matches what the role has been tested with
-    - bioblend==0.10.0
+- name: Create/invoke script virtualenv (Data managers)
+  pip:
+    name:
+      - ephemeris==0.8.0  # Pinned version should make sure ephemeris version matches what the role has been tested with
+      - bioblend==0.10.0
+    state: present
+    virtualenv: "{{ galaxy_tools_base_dir }}/venv"
+    virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
 
 - name: Copy galaxy_tools_data_managers_list in venv
   copy: src="{{ galaxy_tools_data_managers_list }}" dest="{{ galaxy_tools_base_dir }}/venv/bin/data_managers_list.yaml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
-- fail: msg="Installed ansible version {{ ansible_version.full }}, but ansible version > 2.1.1.1 required"
-  when: ansible_version.full | version_compare('2.1.1.1', '<')
+- name: Check ansible version
+  fail:
+    msg: "Installed ansible version {{ ansible_version.full }}, but ansible version > 2.1.1.1 required"
+  when: ansible_version.full is version_compare('2.1.1.1', '<')
 
 - include_tasks: "bootstrap_user.yml"
   vars:

--- a/tasks/tools.yml
+++ b/tasks/tools.yml
@@ -1,10 +1,13 @@
 ---
 
-- name: Create/invoke script virtualenv
-  pip: name={{ item }} virtualenv={{ galaxy_tools_base_dir }}/venv virtualenv_command="{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
-  with_items:
-    - ephemeris==0.8.0  # Pinned version should make sure ephemeris version matches what the role has been tested with
-    - bioblend==0.10.0
+- name: Create/invoke script virtualenv (Tools)
+  pip:
+    name:
+      - ephemeris==0.8.0  # Pinned version should make sure ephemeris version matches what the role has been tested with
+      - bioblend==0.10.0
+    state: present
+    virtualenv: "{{ galaxy_tools_base_dir }}/venv"
+    virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
 
 - include_tasks: install_tool_list.yml
   with_items: '{{ galaxy_tools_tool_list_files }}'

--- a/tasks/workflows.yml
+++ b/tasks/workflows.yml
@@ -1,10 +1,13 @@
 ---
 
-- name: Create/invoke script virtualenv
-  pip: name={{ item }} virtualenv={{ galaxy_tools_base_dir }}/venv virtualenv_command="{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
-  with_items:
-    - pyyaml
-    - bioblend
+- name: Create/invoke script virtualenv (Workflows)
+  pip:
+    name:
+      - pyyaml
+      - bioblend
+    state: present
+    virtualenv: "{{ galaxy_tools_base_dir }}/venv"
+    virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
 
 - name: Place the tool management script
   copy: src=install_workflow.py dest={{ galaxy_tools_base_dir }}/install_workflow.py


### PR DESCRIPTION
Updated the syntax of some tasks to get rid of the deprecation warnings from ansible. Also updated the names of the tasks, since it was hard to differentiate between them/locate them.